### PR TITLE
Replacing deprecated import

### DIFF
--- a/src/app/connect-button/actions/auth.ts
+++ b/src/app/connect-button/actions/auth.ts
@@ -1,6 +1,6 @@
 "use server";
 import { VerifyLoginPayloadParams, createAuth } from "thirdweb/auth";
-import { privateKeyAccount } from "thirdweb/wallets";
+import { privateKeyToAccount } from "thirdweb/wallets";
 import { client } from "../../../lib/client";
 import { cookies } from "next/headers";
 
@@ -12,7 +12,7 @@ if (!privateKey) {
 
 const thirdwebAuth = createAuth({
   domain: process.env.NEXT_PUBLIC_THIRDWEB_AUTH_DOMAIN || "",
-  adminAccount: privateKeyAccount({ client, privateKey }),
+  adminAccount: privateKeyToAccount({ client, privateKey }),
 });
 
 export const generatePayload = thirdwebAuth.generatePayload;

--- a/src/app/jwt-cookie/actions/auth.ts
+++ b/src/app/jwt-cookie/actions/auth.ts
@@ -1,6 +1,6 @@
 "use server";
 import { VerifyLoginPayloadParams, createAuth } from "thirdweb/auth";
-import { privateKeyAccount } from "thirdweb/wallets";
+import { privateKeyToAccount } from "thirdweb/wallets";
 import { client } from "../../../lib/client";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
@@ -13,7 +13,7 @@ if (!privateKey) {
 
 const thirdwebAuth = createAuth({
   domain: process.env.NEXT_PUBLIC_THIRDWEB_AUTH_DOMAIN || "",
-  adminAccount: privateKeyAccount({ client, privateKey }),
+  adminAccount: privateKeyToAccount({ client, privateKey }),
 });
 
 export const generatePayload = thirdwebAuth.generatePayload;


### PR DESCRIPTION
The examples use privateKeyAccount which has been deprecated in favour of privateKeyToAccount, updating the examples to that